### PR TITLE
Fix the unexpected "SyntaxError: Invalid hexadecimal escape sequence"…

### DIFF
--- a/src/node/plugin-api.ts
+++ b/src/node/plugin-api.ts
@@ -446,7 +446,7 @@ abstract class BaseWebviewContainer implements IframeLike {
                     let acquired = false;
                     let extData = ${extData ? `JSON.parse(${JSON.stringify(JSON.stringify(extData))})` : undefined};
                     let i18n = ${this.i18n ? `JSON.parse(${JSON.stringify(JSON.stringify(this.i18n))})` : undefined};
-                    let extensionPath = '${this.context.extensionPath}';
+                    let extensionPath = '${encodeURIComponent(this.context.extensionPath)}';
                     return () => {
                         if (acquired) {
 						    throw new Error('An instance of the CloudIDE Plugin API has already been acquired');
@@ -463,7 +463,7 @@ abstract class BaseWebviewContainer implements IframeLike {
                                 return i18n;
                             },
                             getExtensionPath: function() {
-                                return extensionPath;
+                                return decodeURIComponent(extensionPath);
                             }
                         });
                     };


### PR DESCRIPTION
Fix the unexpected "SyntaxError: Invalid hexadecimal escape sequence" error when extensionPath is prefixed with \x.

This error will result in a blank webview page.