### PR TITLE
Fix the eslint "No files matching the pattern "'src/**/*.{js,ts,tsx}'" were found." error and bump version to 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@codearts/core",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@codearts/core",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@cloudide/messaging": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "codearts",
         "plugin"
     ],
-    "version": "0.5.0",
+    "version": "0.5.1",
     "license": "SEE LICENSE IN LICENSE",
     "description": "core plugin api of cloudide frontend and backend",
     "repository": {
@@ -47,7 +47,7 @@
     "scripts": {
         "prepare": "npm run eslint && npm run build && npm run test",
         "build": "tsc",
-        "eslint": "eslint 'src/**/*.{js,ts,tsx}' --quiet --fix",
+        "eslint": "eslint src/**/*.{js,ts,tsx} --quiet --fix",
         "test": "mocha"
     }
 }


### PR DESCRIPTION
Fix the eslint "No files matching the pattern "'src/**/*.{js,ts,tsx}'" were found." error and bump version to 0.5.1